### PR TITLE
Add support for postgres backends

### DIFF
--- a/locals.tf
+++ b/locals.tf
@@ -17,6 +17,9 @@ locals {
   tier          = var.tier != null ? var.tier : local.default_tier
 
   mysql_users = local.db_engine != "MYSQL" ? {} : {
+    # For every user, create a distict key in the format [user]@[host]
+    # If the host parameter was omitted, use '%' as default and set the
+    # default host in the resulting user object as well
     for user in var.users : "${user.name}@${user.host == null ? "%" : user.host}" => defaults(user, { host = "%" })
   }
   postgres_users = local.db_engine != "POSTGRES" ? {} : { for user in var.users : user.name => user }

--- a/main.tf
+++ b/main.tf
@@ -6,6 +6,10 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 3.70.0"
     }
+    postgresql = {
+      source  = "cyrilgdn/postgresql"
+      version = ">= 1.11.0"
+    }
   }
   experiments = [module_variable_optional_attrs]
 }

--- a/main.tf
+++ b/main.tf
@@ -6,10 +6,6 @@ terraform {
       source  = "hashicorp/google"
       version = ">= 3.70.0"
     }
-    postgresql = {
-      source  = "cyrilgdn/postgresql"
-      version = ">= 1.11.0"
-    }
   }
   experiments = [module_variable_optional_attrs]
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,3 +1,7 @@
+output "connection_name" {
+  value = google_sql_database_instance.instance.connection_name
+}
+
 output "ip_addresses" {
   value = {
     for addr in google_sql_database_instance.instance.ip_address : addr.type => addr.ip_address

--- a/user.tf
+++ b/user.tf
@@ -1,14 +1,25 @@
 resource "random_password" "sql_user" {
-  for_each = local.users
+  for_each = merge(
+    local.mysql_users,
+    local.postgres_users,
+  )
 
   length = 48
 }
 
-resource "google_sql_user" "sql_user" {
-  for_each = local.users
+resource "google_sql_user" "mysql_user" {
+  for_each = local.mysql_users
 
   instance = google_sql_database_instance.instance.name
   name     = each.value.name
   host     = each.value.host
+  password = random_password.sql_user[each.key].result
+}
+
+resource "google_sql_user" "postgres_user" {
+  for_each = local.postgres_users
+
+  instance = google_sql_database_instance.instance.name
+  name     = each.value.name
   password = random_password.sql_user[each.key].result
 }

--- a/user.tf
+++ b/user.tf
@@ -17,9 +17,28 @@ resource "google_sql_user" "mysql_user" {
 }
 
 resource "google_sql_user" "postgres_user" {
-  for_each = local.postgres_users
+  for_each = { for key, user in local.postgres_users : key => user if user.readonly != true }
 
   instance = google_sql_database_instance.instance.name
   name     = each.value.name
   password = random_password.sql_user[each.key].result
+}
+
+resource "postgresql_role" "readonly_roles" {
+  for_each = { for key, user in local.postgres_users : key => user if user.readonly == true }
+
+  login    = true
+  name     = each.value.name
+  password = random_password.sql_user[each.key].result
+}
+
+resource "postgresql_default_privileges" "readonly_privileges" {
+  for_each = { for key, user in local.postgres_users : key => user if user.readonly == true }
+
+  instance    = google_sql_database_instance.instance.name
+  role        = postgresql_role.readonly_roles[each.key].name
+  owner       = "postgres"
+  schema      = "public"
+  object_type = "table"
+  privileges  = ["SELECT"]
 }

--- a/user.tf
+++ b/user.tf
@@ -42,3 +42,19 @@ resource "postgresql_default_privileges" "readonly_privileges" {
   object_type = "table"
   privileges  = ["SELECT"]
 }
+
+resource "postgresql_grant" "readonly_grants" {
+  for_each = merge(
+    [
+      for key, user in local.postgres_users : {
+        for db in var.databases : "${db}/${key}" => user if user.readonly == true
+      }
+    ]...
+  )
+
+  database    = google_sql_database.pararius_office.name
+  role        = postgresql_role.readonly_roles[each.value].name
+  schema      = "public"
+  object_type = "table"
+  privileges  = []
+}

--- a/variables.tf
+++ b/variables.tf
@@ -75,6 +75,5 @@ variable "users" {
   type = list(object({
     name     = string
     host     = optional(string)
-    readonly = optional(bool)
   }))
 }

--- a/variables.tf
+++ b/variables.tf
@@ -74,7 +74,7 @@ variable "tier" {
 variable "users" {
   type = list(object({
     name     = string
-    host     = string
+    host     = optional(string)
     readonly = optional(bool)
   }))
 }


### PR DESCRIPTION
Breaking change: mysql user resource got renamed, requiring `terraform
state mv`
```diff
-resource "google_sql_user" "sql_user" {
+resource "google_sql_user" "mysql_user" {
```