### PR TITLE
Ignore DB collation/charset

### DIFF
--- a/database.tf
+++ b/database.tf
@@ -3,12 +3,4 @@ resource "google_sql_database" "database" {
 
   instance  = google_sql_database_instance.instance.name
   name      = each.value
-  charset   = "utf8"
-  collation = "utf8_general_ci"
-
-  lifecycle {
-    ignore_changes = [
-      "collation",
-    ]
-  }
 }

--- a/database.tf
+++ b/database.tf
@@ -5,4 +5,10 @@ resource "google_sql_database" "database" {
   name      = each.value
   charset   = "utf8"
   collation = "utf8_general_ci"
+
+  lifecycle {
+    ignore_changes = [
+      "collation",
+    ]
+  }
 }


### PR DESCRIPTION
until proper collation support will be added to the module.

Wonder if we should adjust the default collation as well, based on https://cloud.google.com/sql/docs/postgres/create-manage-databases#create. Kinda curious what the rationale was behind picking `utf8_general_ci` for those DBs that served as example for the module :wink: