### PR TITLE
Improve readability of instance name prefix logic

### DIFF
--- a/instance.tf
+++ b/instance.tf
@@ -1,6 +1,6 @@
 resource "google_sql_database_instance" "instance" {
   database_version     = var.database_version
-  name                 = "${var.project_prefix != null ? "${var.project_prefix}-" : ""}${var.instance_name}"
+  name                 = var.project_prefix == null ? var.instance_name : "${var.project_prefix}-${var.instance_name}"
   deletion_protection  = var.deletion_protection
   master_instance_name = var.primary_instance_name
   settings {


### PR DESCRIPTION
If this is indeed deemed to be an improvement, we should update the [PostgreSQL version](https://github.com/Pararius/terraform-module-gcp-cloudsql-postgres/blob/main/instance.tf#L3) as well.