### PR TITLE
Set edition to ENTERPRISE

### DIFF
--- a/instance.tf
+++ b/instance.tf
@@ -55,4 +55,8 @@ resource "google_sql_database_instance" "instance" {
       }
     }
   }
+
+  lifecycle {
+    ignore_changes = [settings.edition]
+  }
 }

--- a/instance.tf
+++ b/instance.tf
@@ -57,6 +57,8 @@ resource "google_sql_database_instance" "instance" {
   }
 
   lifecycle {
-    ignore_changes = [settings["edition"]]
+    ignore_changes = [
+      settings["edition"], # Readonly field which tends to cause perma-diffs
+    ]
   }
 }

--- a/instance.tf
+++ b/instance.tf
@@ -17,6 +17,7 @@ resource "google_sql_database_instance" "instance" {
     disk_autoresize_limit = var.storage_limit
     disk_size             = local.storage_size
     disk_type             = "PD_SSD"
+    edition               = "ENTERPRISE"
     tier                  = local.tier
     user_labels           = local.labels
     backup_configuration {

--- a/instance.tf
+++ b/instance.tf
@@ -57,6 +57,6 @@ resource "google_sql_database_instance" "instance" {
   }
 
   lifecycle {
-    ignore_changes = [settings.edition]
+    ignore_changes = [settings["edition"]]
   }
 }


### PR DESCRIPTION
Prevents perma-diff:
```terraform
Terraform will perform the following actions:

  # module.mysql8_instance[0].google_sql_database_instance.instance will be updated in-place
  ~ resource "google_sql_database_instance" "instance" {
        id                             = "primary1-mysql80"
        name                           = "primary1-mysql80"
        # (14 unchanged attributes hidden)

      ~ settings {
          - edition                     = "ENTERPRISE" -> null
            # (12 unchanged attributes hidden)

            # (8 unchanged blocks hidden)
        }
    }

Plan: 0 to add, 1 to change, 0 to destroy.
```