### PR TITLE
Properly ignore edition setting

### DIFF
--- a/instance.tf
+++ b/instance.tf
@@ -58,7 +58,7 @@ resource "google_sql_database_instance" "instance" {
 
   lifecycle {
     ignore_changes = [
-      settings["edition"], # Readonly field which tends to cause perma-diffs
+      settings[0].edition # Readonly field which tends to cause perma-diffs
     ]
   }
 }


### PR DESCRIPTION
* Instances pre-dating the whole Enterprise/Enterprise Plus stuff don't have that setting exposed in the API
* The [documented](https://developer.hashicorp.com/terraform/language/meta-arguments/lifecycle#ignore_changes) method of ignoring doesn't work, as it ignored the whole `settings` block. Solution found on [Stack Overflow](https://stackoverflow.com/a/57002238) does work as intended though.